### PR TITLE
Fix error in Internet Explorer browsers

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -26,7 +26,7 @@ export function getSVGFromSource(src) {
     const svgContainer = document.createElement('div');
     svgContainer.innerHTML = src;
     const svg = svgContainer.firstElementChild;
-    svg.remove(); // deref from parent element
+    svg.parentNode.removeChild(svg); // deref from parent element
     return svg;
 }
 


### PR DESCRIPTION
IE(up until Edge) doesn't support .remove method on a DOM node, thus using this component will brake React applications. We can easily achieve the same result without using remove method by using .removeChild on a parent node.